### PR TITLE
Memoize getJSON call so it's called only once per unique parameters

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -461,10 +461,15 @@ function getImage(image_url) {
     });
 }
 
-async function get(url, params, cache = CACHE_LIFETIME, base_url = BOORU) {
+const getJSONMemoized = _.memoize(
+    (url, params) => $.getJSON(url, params),
+    (url, params) => url + $.param(params)
+);
+
+function get(url, params, cache = CACHE_LIFETIME, base_url = BOORU) {
     const timestamp = Math.round((Date.now() / 1000 / cache));
     params = { ...params, expiry: 365, timestamp: timestamp };
-    return await $.getJSON(`${base_url}${url}.json`, params);
+    return getJSONMemoized(`${base_url}${url}.json`, params);
 }
 
 async function addTranslation($element, tag = $element.text()) {


### PR DESCRIPTION
Since a caching mechanism is being used, there should only need to be one call to the getJSON function for each unique set of parameters.  Subsequent calls will await on the promise returned by the first call.

Also, the ``get`` function does not need to be an asynchronous function since the outer function is using **await**.  This avoids the promise getting unwrapped, re-wrapped, then unwrapped again.

### Timelines

- Original method: https://media.discordapp.net/attachments/310846683376517121/556210927268003862/unknown.png
- Memoized method: https://cdn.discordapp.com/attachments/310846683376517121/556213017449201684/unknown.png
