### PR TITLE
Add translations for Twitter hashtags

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -180,6 +180,10 @@ $("head").append(`
         white-space: nowrap;
     }
 
+    #ex-twitter .ex-translated-tags * {
+        white-space: inherit;
+    }
+
     .ex-translated-tags::before {
         content: "(";
         white-space: nowrap;
@@ -839,14 +843,20 @@ function buildPostPreview(post) {
     `;
 }
 
-function asyncAddTranslation(tagSelector, tagLink = "> a") {
+function getTagPreload(tag, tagLink, isContainer) {
+    if (isContainer) {
+        return [$(tag),$(tag).find(tagLink).text()];
+    } else {
+        return [$(tag).find(tagLink),undefined];
+    }
+}
+
+function asyncAddTranslation(tagSelector, tagLink = "> a", isContainer = false) {
     $(tagSelector).each((i, tag) => {
-        const $tag = $(tag).find(tagLink);
-        addTranslation($tag);
+        addTranslation(...getTagPreload(tag, tagLink, isContainer));
     });
     onElementsAdded(tagSelector, tag => {
-        const $tag = $(tag).find(tagLink);
-        addTranslation($tag);
+        addTranslation(...getTagPreload(tag, tagLink, isContainer));
     });
 }
 
@@ -1040,6 +1050,8 @@ function initializeHentaiFoundry() {
 
 function initializeTwitter() {
     $("body").attr("id", "ex-twitter");
+
+    asyncAddTranslation(".twitter-hashtag", ">b", true);
 
     asyncAddTranslatedArtists(".ProfileHeaderCard-screennameLink");
     asyncAddTranslatedArtists(".ProfileCard-screennameLink")


### PR DESCRIPTION
On Twitter, the hashtag links are the containers themselves, so the code had to be adjusted accordingly. 

Also, the text when viewing an individual Tweet is jumbo-sized, causing very long tags to overflow outside of the Tweet, so the text wrapping was reset to what is used by Twitter.