### PR TITLE
Rework background color chooser

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -637,6 +637,30 @@ async function attachShadow(target, callback) {
     }
 }
 
+function chooseBackgroundColorScheme($element) {
+    const TRANSPARENT_COLOR = "rgba(0, 0, 0, 0)";
+    //Halfway between white/black in the RGB scheme
+    const MIDDLE_LUMINOSITY = 128;
+
+    // Get background color of closest parent element with a nontransparent background color
+    let background_color = $element.parents().filter((i,el) => $(el).css("background-color") !== TRANSPARENT_COLOR).css("background-color");
+    let color_array = background_color.match(/\d+/g).map(Number);
+    let median_luminosity = (Math.max(...color_array) + Math.min(...color_array)) / 2;
+    let qtip_class = (median_luminosity < MIDDLE_LUMINOSITY ? "qtip-dark" : "qtip-light");
+    let adjusted_array = color_array.map((color)=>{
+        let color_scale = (color - MIDDLE_LUMINOSITY) / MIDDLE_LUMINOSITY;
+        let adjusted_color = ((Math.abs(color_scale)**0.7) //Exponentiation to reduce the scale
+                             * Math.sign(color_scale)      //Get original sign back
+                             * MIDDLE_LUMINOSITY)          //Get original amplitude back
+                             + MIDDLE_LUMINOSITY;          //Get back to the RGB color range
+        return Math.round(adjusted_color);
+    });
+    let adjusted_color = (adjusted_array.length === 3 ?
+                          `rgb(${adjusted_array[0]}, ${adjusted_array[1]}, ${adjusted_array[2]})` :
+                          `rgba(${adjusted_array[0]}, ${adjusted_array[1]}, ${adjusted_array[2]}, , ${adjusted_array[3]})`);
+    return [qtip_class,adjusted_color];
+}
+
 async function buildArtistTooltip(artist, qtip) {
     attachShadow(qtip.elements.content.get(0), async () => {
         if (!(artist.name in rendered_qtips)) {
@@ -663,13 +687,12 @@ async function buildArtistTooltip(artist, qtip) {
         }
         return rendered_qtips[artist.name].clone();
     });
-    // get background color of closest parent element with a bg color
-    let bgcolor = qtip.elements.target.parents().filter((i,el) => $(el).css("background-color")!="rgba(0, 0, 0, 0)").css("background-color");
+    // select the class and background color based upon the background of surrounding elements
+    let [qtip_class,adjusted_color] = chooseBackgroundColorScheme(qtip.elements.target);
     // set dark or light theme depending on the bg color
-    qtip.elements.tooltip.addClass((((([r,g,b]) => (Math.max(r,g,b)+Math.min(r,g,b))/2)(bgcolor.match(/\d+/g)) < 128) ? "qtip-dark" : "qtip-light"));
+    qtip.elements.tooltip.addClass(qtip_class);
     // make the bg color lighter/darker and apply
-    bgcolor = bgcolor.replace(/\d+/g, n => (n=(n-128)/128, (Math.abs(n)**0.7)*Math.sign(n)*128+128));
-    qtip.elements.tooltip.css("background-color", bgcolor);
+    qtip.elements.tooltip.css("background-color", adjusted_color);
 }
 
 function buildArtistTooltipHtml(artist, tag, posts) {

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -658,7 +658,7 @@ function chooseBackgroundColorScheme($element) {
     });
     let adjusted_color = (adjusted_array.length === 3 ?
                           `rgb(${adjusted_array[0]}, ${adjusted_array[1]}, ${adjusted_array[2]})` :
-                          `rgba(${adjusted_array[0]}, ${adjusted_array[1]}, ${adjusted_array[2]}, , ${adjusted_array[3]})`);
+                          `rgba(${adjusted_array[0]}, ${adjusted_array[1]}, ${adjusted_array[2]}, ${adjusted_array[3]})`);
     return [qtip_class,adjusted_color];
 }
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -6,6 +6,7 @@
 // @homepageURL  https://github.com/evazion/translate-pixiv-tags
 // @supportURL   https://github.com/evazion/translate-pixiv-tags/issues
 // @updateURL    https://github.com/evazion/translate-pixiv-tags/raw/stable/translate-pixiv-tags.user.js
+// @downloadURL  https://github.com/evazion/translate-pixiv-tags/raw/stable/translate-pixiv-tags.user.js
 // @match        *://www.pixiv.net/*
 // @match        *://dic.pixiv.net/*
 // @match        *://nijie.info/*


### PR DESCRIPTION
The following section added in cd4654a6962c9f7f3ddad1bb76a8776d4054ca13 is way too compact to be understood/maintainable.

https://github.com/evazion/translate-pixiv-tags/blob/cd4654a6962c9f7f3ddad1bb76a8776d4054ca13/translate-pixiv-tags.user.js#L666-L672

I expanded it out and added comments where I thought it was needed, and added named variables as I understood what's going on. Also, I'm not sure where that formula was pulled from, but if it has a source then that could be added in as well as renaming the variables if appropriate.

The second commit is actually needed to support copy/paste installations. As it is, if someone installed using that method, then the update link does not get populated, at least not with TamperMonkey. The following is the update link I'm talking about.

![image](https://user-images.githubusercontent.com/21149935/62027676-29bbe780-b193-11e9-9a95-7042fb65e161.png)