### PR TITLE
Migrate to library GM shim

### DIFF
--- a/lib/jquery-gm-shim.js
+++ b/lib/jquery-gm-shim.js
@@ -1,0 +1,90 @@
+// https://gist.github.com/monperrus/999065
+// This is a shim that adapts jQuery's ajax methods to use GM_xmlhttpRequest.
+// This allows us to use $.getJSON instead of using GM_xmlhttpRequest directly.
+//
+// This is necessary because some sites (e.g. Twitter, DeviantArt) have a
+// Content Security Policy that blocks us from making cross-origin requests to
+// Danbooru. Tampermonkey allows us to bypass the CSP, but only if we use GM_xmlhttpRequest.
+function GM_XHR(xmlhttpRequest) {
+    this.type = null;
+    this.url = null;
+    this.async = null;
+    this.username = null;
+    this.password = null;
+    this.status = null;
+    this.readyState = null;
+    this.headers = {};
+    this.xmlhttpRequest = xmlhttpRequest;
+
+    this.abort = function() {
+        this.readyState = 0;
+    };
+
+    this.getAllResponseHeaders = function(name) {
+        if (this.readyState != 4) return "";
+        return this.responseHeaders;
+    };
+
+    this.getResponseHeader = function(name) {
+        var regexp = new RegExp('^'+name+': (.*)$','im');
+        var match = regexp.exec(this.responseHeaders);
+        if (match) { return match[1]; }
+        return '';
+    };
+
+    this.open = function(type, url, async, username, password) {
+        this.type = type ? type : null;
+        this.url = url ? url : null;
+        this.async = async ? async : null;
+        this.username = username ? username : null;
+        this.password = password ? password : null;
+        this.readyState = 1;
+    };
+
+    this.setRequestHeader = function(name, value) {
+        this.headers[name] = value;
+    };
+
+    this.onresponse = function (handler) {
+        let xhr = this;
+
+        return function (resp) {
+            xhr.readyState = resp.readyState;
+            xhr.responseHeaders = resp.responseHeaders;
+            xhr.responseText = resp.responseText;
+            xhr.status = resp.status;
+            xhr.statusText = resp.statusText;
+
+            if (xhr[handler]) {           // if (xhr.onload) {
+                xhr[handler].call(xhr);   //     xhr.onload();
+            } else {
+                xhr.onreadystatechange();
+            }
+        };
+    };
+
+    this.send = function(data) {
+        this.data = data;
+
+        this.xmlhttpRequest({
+            method: this.type,
+            url: this.url,
+            headers: this.headers,
+            data: this.data,
+            responseType: this.responseType,
+            onload: this.onresponse("onload"),
+            onerror: this.onresponse("onerror"),
+        });
+    };
+}
+
+function GM_jQuery_setup() {
+    // https://www.greasespot.net/2017/09/greasemonkey-4-for-script-authors.html
+    // In Greasemonkey 4+ / Tampermonkey 4.5+, use GM.xmlHttpRequest. In earlier
+    // versions, use GM_xmlhttpRequest.
+    if (typeof GM !== "undefined" && GM.xmlHttpRequest !== undefined) {
+        $.ajaxSetup({ xhr: () => new GM_XHR(GM.xmlHttpRequest) });
+    } else {
+        $.ajaxSetup({ xhr: () => new GM_XHR(GM_xmlhttpRequest) });
+    }
+}

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -28,6 +28,7 @@
 // @require      https://raw.githubusercontent.com/rafaelw/mutation-summary/421110f84178aa9e4098b38df83f727e5aea3d97/src/mutation-summary.js
 // @require      https://cdnjs.cloudflare.com/ajax/libs/qtip2/3.0.3/jquery.qtip.js
 // @require      https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore.js
+// @require      https://github.com/BrokenEagle/translate-pixiv-tags/raw/Lib-20190829/lib/jquery-gm-shim.js
 // @resource     jquery_qtip_css https://cdnjs.cloudflare.com/ajax/libs/qtip2/3.0.3/jquery.qtip.min.css
 // @connect      donmai.us
 // @noframes
@@ -157,95 +158,6 @@ const CORS_IMAGE_DOMAINS = [
 
 //Memory storage for already rendered artist tooltips
 const rendered_qtips = {};
-
-// https://gist.github.com/monperrus/999065
-// This is a shim that adapts jQuery's ajax methods to use GM_xmlhttpRequest.
-// This allows us to use $.getJSON instead of using GM_xmlhttpRequest directly.
-//
-// This is necessary because some sites (e.g. Twitter, DeviantArt) have a
-// Content Security Policy that blocks us from making cross-origin requests to
-// Danbooru. Tampermonkey allows us to bypass the CSP, but only if we use GM_xmlhttpRequest.
-function GM_XHR(xmlhttpRequest) {
-    this.type = null;
-    this.url = null;
-    this.async = null;
-    this.username = null;
-    this.password = null;
-    this.status = null;
-    this.readyState = null;
-    this.headers = {};
-    this.xmlhttpRequest = xmlhttpRequest;
-
-    this.abort = function() {
-        this.readyState = 0;
-    };
-
-    this.getAllResponseHeaders = function(name) {
-        if (this.readyState != 4) return "";
-        return this.responseHeaders;
-    };
-
-    this.getResponseHeader = function(name) {
-        var regexp = new RegExp('^'+name+': (.*)$','im');
-        var match = regexp.exec(this.responseHeaders);
-        if (match) { return match[1]; }
-        return '';
-    };
-
-    this.open = function(type, url, async, username, password) {
-        this.type = type ? type : null;
-        this.url = url ? url : null;
-        this.async = async ? async : null;
-        this.username = username ? username : null;
-        this.password = password ? password : null;
-        this.readyState = 1;
-    };
-
-    this.setRequestHeader = function(name, value) {
-        this.headers[name] = value;
-    };
-
-    this.onresponse = function (handler) {
-        let xhr = this;
-
-        return function (resp) {
-            xhr.readyState = resp.readyState;
-            xhr.responseHeaders = resp.responseHeaders;
-            xhr.responseText = resp.responseText;
-            xhr.status = resp.status;
-            xhr.statusText = resp.statusText;
-
-            if (xhr[handler]) {           // if (xhr.onload) {
-                xhr[handler].call(xhr);   //     xhr.onload();
-            } else {
-                xhr.onreadystatechange();
-            }
-        };
-    };
-
-    this.send = function(data) {
-        this.data = data;
-
-        this.xmlhttpRequest({
-            method: this.type,
-            url: this.url,
-            headers: this.headers,
-            data: this.data,
-            responseType: this.responseType,
-            onload: this.onresponse("onload"),
-            onerror: this.onresponse("onerror"),
-        });
-    };
-}
-
-// https://www.greasespot.net/2017/09/greasemonkey-4-for-script-authors.html
-// In Greasemonkey 4+ / Tampermonkey 4.5+, use GM.xmlHttpRequest. In earlier
-// versions, use GM_xmlhttpRequest.
-if (typeof GM !== "undefined" && GM.xmlHttpRequest !== undefined) {
-    $.ajaxSetup({ xhr: () => new GM_XHR(GM.xmlHttpRequest) });
-} else {
-    $.ajaxSetup({ xhr: () => new GM_XHR(GM_xmlhttpRequest) });
-}
 
 const PROGRAM_CSS = `
 .ex-translated-tags {
@@ -1706,6 +1618,7 @@ function initializePawoo() {
 }
 
 function initialize() {
+    GM_jQuery_setup();
     installStyle(PROGRAM_CSS);
     installStyle(GM_getResourceText('jquery_qtip_css'));
 


### PR DESCRIPTION
Moved the script code unrelated to the main functionality out into its own library file.

Note that a new tag/release will need to be created, and the commit 9e9a60e will have to be edited or a commit will need to be added to point to the tag on the **evazion** repository instead.

The reason a tag is being used is that it provides a convenient mechanism that branches don't have which can force the userscript to use a newer version of external files as required. This is because the external resource checker only checks weekly by default, and can be set to never as well. However, if the URL changes, which is what happens when a new tag gets added, the userscript manager is forced to dump the current file and get the new file.