### PR TITLE
Apply network rate limiting to calls per domain

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -287,10 +287,10 @@ async function getJSONRateLimited(url, params) {
     rate_limit_request[domain] = rate_limit_request[domain] || {pending: 0, log: true};
     //Wait until the number of pending network requests is below the max threshold
     while (rate_limit_request[domain].pending >= max_pending_network_requests) {
-        logPendingWarning(domain)
+        logPendingWarning(domain);
         await new Promise(resolve => setTimeout(resolve, 500)); //Sleep half a second
     }
-    rate_limit_request[domain].pending++
+    rate_limit_request[domain].pending++;
     return $.getJSON(url, params).always(()=>{rate_limit_request[domain].pending--;});
 }
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -283,12 +283,13 @@ function logPendingWarning(domain) {
 }
 
 async function getJSONRateLimited(url, params) {
+    const sleepHalfSecond = resolve => setTimeout(resolve, 500);
     let domain = new URL(url).hostname;
     rate_limit_request[domain] = rate_limit_request[domain] || {pending: 0, log: true};
     //Wait until the number of pending network requests is below the max threshold
     while (rate_limit_request[domain].pending >= max_pending_network_requests) {
         logPendingWarning(domain);
-        await new Promise(resolve => setTimeout(resolve, 500)); //Sleep half a second
+        await new Promise(sleepHalfSecond);
     }
     rate_limit_request[domain].pending++;
     return $.getJSON(url, params).always(()=>{rate_limit_request[domain].pending--;});


### PR DESCRIPTION
After being pointed to the Pixiv tags page below by @7nik, I worked on some network rate limiting code which can send the same amount of network requests but without all of the network errors.

https://www.pixiv.net/tags.php

I set the max threshold to 40 because that was what still worked, as 50 was giving me errors. To test it out on the above page, set the cache threshold low so that the network calls aren't going to cache. Since it logs one message per second, it provides a convenient measure to determine how long the whole process takes. Below are the approximate time it takes to load the above page going all to network and then mostly to cache (since some calls always go to network).

- All network: 22 seconds
- Mostly cache: 6 seconds