### PR TITLE
Handle network errors

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -275,16 +275,12 @@ function getImage(image_url) {
         .then(resp => resp.response);
 }
 
-function rateLimitedLog() {
-    //The last parameter is the level of logging
-    let level = arguments[arguments.length - 1];
-    //Removes the last parameter
-    arguments.length -= 1;
+function rateLimitedLog(level, ...messageData) {
     //Assumes that only simple arguments will be passed in
-    let key = [...arguments].join(',');
+    let key = messageData.join(',');
     rateLimitedLog[key] = rateLimitedLog[key] || {log: true};
     if (rateLimitedLog[key].log) {
-        console[level](...arguments);
+        console[level](...messageData);
         rateLimitedLog[key].log = false;
         //Have only one message with the same parameters per second
         setTimeout(()=>{rateLimitedLog[key].log = true;}, 1000);
@@ -297,7 +293,7 @@ function checkNetworkErrors(domain,hasError) {
         console.log("Total errors:", ++checkNetworkErrors[domain].error);
     }
     if (checkNetworkErrors[domain].error >= MAX_NETWORK_ERRORS) {
-        rateLimitedLog("Maximun number of errors exceeded", MAX_NETWORK_ERRORS, "for", domain, 'error');
+        rateLimitedLog("error", "Maximun number of errors exceeded", MAX_NETWORK_ERRORS, "for", domain);
         return false;
     }
     return true;
@@ -313,7 +309,7 @@ async function getJSONRateLimited(url, params) {
         if (!(checkNetworkErrors(domain, false))) {
             return [];
         }
-        rateLimitedLog("Exceeded maximum pending requests", getJSONRateLimited[domain].current_max, "for", domain, 'warn');
+        rateLimitedLog("warn", "Exceeded maximum pending requests", getJSONRateLimited[domain].current_max, "for", domain);
         await new Promise(sleepHalfSecond);
     }
     for (let i = 0; i < MAX_NETWORK_RETRIES; i++) {


### PR DESCRIPTION
I went back to that Pixiv tags page the other day, and I was still noting the occasional error. So I added in a retry mechanism, an early bail for too many network errors, and a backoff mechanism for slower network conditions. The early bail will help detect and stop processing under bad network conditions or Downbooru.

During testing of this pull at the 40 max pending requests, there were on average a few to no network errors, although occasionally I did see more than 10.  Also, the rate of network errors always slowed down as the script backed off the current max pending. Therefore I felt like 25 max network errors was probably the right number to use. Especially since during regular operations a user shouldn't be stressing out a system so much with 500 network requests all at once, and the worst that will happen is that the page will load partially. The user could potentially be notified of this, but there currently isn't such a mechanism plus that was outside the scope for this change

Just to add in some additional observations, but the tags page was also tested at 50 max pending requests, and the error rate was much higher, usually at least 20 or more. So if the max pending requests is ever raised, the max network requests will also need to be raised.