### PR TITLE
Use safe regex match function for singular code lines

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -268,6 +268,15 @@ function noIndents(strings, ...values) {
     return res.join("");
 }
 
+//For safe ways to use regexes in a single line of code
+function safeMatch(string, regex, group = 0, default_value = "") {
+    let match = string.match(regex);
+    if (match) {
+        return match[group];
+    }
+    return default_value;
+}
+
 function getImage(image_url) {
     return GM.xmlHttpRequest({
             method: "GET",
@@ -808,7 +817,7 @@ function buildArtistTooltipContent(artist, [tag = {post_count:0}], posts = []) {
 }
 
 function buildArtistUrlsHtml(artist) {
-    const domainSorter = artist_url => new URL(artist_url.normalized_url).host.match(/[^.]*\.[^.]*$/)[0];
+    const domainSorter = artist_url => safeMatch(new URL(artist_url.normalized_url).host, /[^.]*\.[^.]*$/);
     const artist_urls = _(artist.urls).chain()
                                       .uniq('normalized_url')
                                       .sortBy('normalized_url')
@@ -1449,7 +1458,7 @@ function initializeTwitter() {
         asyncMode: true,
     });
     // floating name of a channel https://twitter.com/mugosatomi
-    const URLfromLocation = () => "https://twitter.com"+(window.location.pathname.match(/\/\w+/)||[])[0];
+    const URLfromLocation = () => "https://twitter.com" + safeMatch(window.location.pathname, /\/\w+/);
     findAndTranslate("artist", "div.css-1dbjc4n.r-xoduu5.r-18u37iz.r-dnmrzs", {
         predicate: "h2>div>div>div",
         toProfileUrl: URLfromLocation,
@@ -1652,7 +1661,7 @@ function initializePawoo() {
     // https://pawoo.net/@yamadorikodi
     // artist name in his card info
     findAndTranslate("artist", ".name small", {
-        toProfileUrl: () => "https://pawoo.net" + window.location.pathname.match(/\/[^\/]+/)[0],
+        toProfileUrl: () => "https://pawoo.net" + safeMatch(window.location.pathname, /\/[^\/]+/),
         tagPosition: "afterbegin"
     });
     // post author, commentor


### PR DESCRIPTION
I noticed qTip errors for the following artist:

https://www.pixiv.net/member_illust.php?id=6638325
https://danbooru.donmai.us/artists/188558

Looking into it, it seems like it's because one of the URLs is malformed. That is one issue, however the issue also exists that some of the regex matching was being done unsafely, i.e. they generate exceptions when there is no match. I've noticed similar issues in my own code, and I've been working to root them out.

But rather than fixing it in just that place, I went around and fixed all other similar places, and since there was enough of them I just created a specialized function for it.