### PR TITLE
Memoized more functions

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -525,7 +525,7 @@ function addDanbooruTags ($target, tags, options = {}) {
                 .join(", ")}
             </span>`);
     }
-    const $tagsContainer = renderedTags[key].clone();
+    const $tagsContainer = renderedTags[key].clone().prop("className", classes);
     insertTag($target, $tagsContainer);
 
     if (onadded) onadded($tagsContainer, options);
@@ -626,7 +626,7 @@ function addDanbooruArtist ($target, artist, options = {}) {
                 </a>
             </div>`);
     }
-    const $tag = renderedArtists[artist.id].clone();
+    const $tag = renderedArtists[artist.id].clone().prop("className", classes);
     insertTag($target, $tag);
     $tag.find("a").qtip(qtipSettings);
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -501,6 +501,7 @@ async function translateTag (target, tagName, options) {
 function addDanbooruTags ($target, tags, options = {}) {
     if (tags.length === 0) return;
 
+    const renderedTags = addDanbooruTags.cache || (addDanbooruTags.cache = {});
     const {
         classes = "",
         onadded = null, // ($tag, options)=>{},
@@ -509,18 +510,22 @@ function addDanbooruTags ($target, tags, options = {}) {
         } = {},
     } = options;
 
-    const $tagsContainer = $(noIndents`
-        <span class="ex-translated-tags ${classes}">
-            ${tags.map((tag) => (
-                noIndents`
-                <a class="ex-translated-tag-category-${tag.category}"
-                   href="${BOORU}/posts?tags=${encodeURIComponent(tag.name)}"
-                   target="_blank">
-                        ${_.escape(tag.prettyName)}
-                </a>`
-            ))
-            .join(", ")}
-        </span>`);
+    const key = tags.map((tag) => tag.name).join("");
+    if (!(key in renderedTags)) {
+        renderedTags[key] = $(noIndents`
+            <span class="ex-translated-tags ${classes}">
+                ${tags.map((tag) => (
+                    noIndents`
+                    <a class="ex-translated-tag-category-${tag.category}"
+                       href="${BOORU}/posts?tags=${encodeURIComponent(tag.name)}"
+                       target="_blank">
+                            ${_.escape(tag.prettyName)}
+                    </a>`
+                ))
+                .join(", ")}
+            </span>`);
+    }
+    const $tagsContainer = renderedTags[key].clone();
     insertTag($target, $tagsContainer);
 
     if (onadded) onadded($tagsContainer, options);
@@ -582,6 +587,7 @@ async function translateArtistByName (element, artistName, options) {
 }
 
 function addDanbooruArtist ($target, artist, options = {}) {
+    const renderedArtists = addDanbooruArtist.cache || (addDanbooruArtist.cache = {});
     const {
         onadded = null, // ($tag, options)=>{},
         tagPosition: {
@@ -612,12 +618,15 @@ function addDanbooruArtist ($target, artist, options = {}) {
         return;
     }
 
-    const $tag = $(noIndents`
-        <div class="${classes}">
-            <a href="${BOORU}/artists/${artist.id}" target="_blank">
-                ${artist.escapedName}
-            </a>
-        </div>`);
+    if (!(artist.id in renderedArtists)) {
+        renderedArtists[artist.id] = $(noIndents`
+            <div class="${classes}">
+                <a href="${BOORU}/artists/${artist.id}" target="_blank">
+                    ${artist.escapedName}
+                </a>
+            </div>`);
+    }
+    const $tag = renderedArtists[artist.id].clone();
     insertTag($target, $tag);
     $tag.find("a").qtip(qtipSettings);
 


### PR DESCRIPTION
- Only memoized functions that were more likely to get the same parameters
- Only used memoized functions in places that were more likely to use the same parameters
- This did not include any of the artist functions since the qTip gets saved in memory
- Adjusted the memoized getJSON function to use the new memoize key generator

I could have also memoized the `timeToAgo` and `formatBytes`, but I considered it unlikely that there would ever be an instance where they would get the same parameters.

@7nik I was also thinking that the menu created by `showSettings` could be kept in memory like the artist qTips are instead of being built each time the settings menu gets called, but I'll leave that to a separate PR/commit. You can do it if you want, or I can do it if you want me to.