### PR TITLE
Use network batch requests

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -671,16 +671,44 @@ async function getLong (url, params, requests, type) {
         let found = [];
         if (NETWORK_REQUEST_DICT[type].data_type === "string") {
             // Check for matching case-insensitive results
-            found = finalResp.filter((data) => data[dataKey].toLowerCase() === request.item.toLowerCase());
+            found = filterStringData(finalResp, dataKey, request.item);
         } else if (NETWORK_REQUEST_DICT[type].data_type === "array") {
             // Check for inclusion of case-insensitive results
-            found = finalResp.filter((data) => {
-                const compareArray = data[dataKey].map((item) => item.toLowerCase());
-                return compareArray.includes(request.item.toLowerCase());
-            });
+            found = filterArrayData(finalResp, dataKey, request.item);
         }
         // Fulfill the promise which returns the results to the function that queued it
         request.promise.resolve(found);
+    });
+    const unusedData = finalResp.filter((data) => !data.used);
+    if (unusedData.length > 0) {
+        debuglog("Unused results found:", unusedData);
+    }
+}
+
+function filterStringData (resp, dataKey, requestItem) {
+    return resp.filter((data) => {
+        if (data[dataKey].toLowerCase() === requestItem.toLowerCase()) {
+            // Because the linter was complaining about assiging to the function parameter
+            const changeData = data;
+            // Used to find any results that don't match any requests
+            changeData.used = true;
+            return true;
+        }
+        return false;
+    });
+}
+
+function filterArrayData (resp, dataKey, requestItem) {
+    return resp.filter((data) => {
+        const compareArray = data[dataKey].map((item) => item.toLowerCase());
+        if (compareArray.includes(requestItem.toLowerCase())) {
+            // Because the linter was complaining about assiging to the function parameter
+            const changeData = data;
+            // Used to find any results that don't match any requests
+            changeData.used = true;
+            return true;
+        }
+        return false;
     });
 }
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1730,7 +1730,7 @@ function initializePixiv () {
     });
 
     // Artist profile pages: https://www.pixiv.net/en/users/29310, https://www.pixiv.net/en/users/104471/illustrations
-    const normalizePageUrl = () => `https://www.pixiv.net/en/users/${safeMatch(window.location.pathname, /\d+/)}`;
+    const normalizePageUrl = () => `https://www.pixiv.net/en/users/${safeMatchMemoized(window.location.pathname, /\d+/)}`;
     findAndTranslate("artist", ".VyO6wL2", {
         toProfileUrl: normalizePageUrl,
         asyncMode: true,
@@ -2089,7 +2089,7 @@ function initializeTwitter () {
 
     // Floating name of a channel https://twitter.com/mugosatomi
     const URLfromLocation = () => (
-        `https://twitter.com${safeMatch(window.location.pathname, /\/\w+/)}`
+        `https://twitter.com${safeMatchMemoized(window.location.pathname, /\/\w+/)}`
     );
     findAndTranslate("artist", "div[data-testid='primaryColumn']>div>:first-child h2>div>div>div", {
         toProfileUrl: URLfromLocation,
@@ -2348,7 +2348,7 @@ function initializePawoo () {
     // https://pawoo.net/@yamadorikodi
     // artist name in channel header
     findAndTranslate("artist", ".name small", {
-        toProfileUrl: (el) => `https://pawoo.net/@${safeMatch(el.textContent, /[^@]+/)}`,
+        toProfileUrl: (el) => `https://pawoo.net/@${safeMatchMemoized(el.textContent, /[^@]+/)}`,
         tagPosition: TAG_POSITIONS.afterbegin,
         ruleName: "artist profile",
     });

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -809,8 +809,7 @@ async function translateArtistByURL (element, profileUrl, options) {
     if (translatedUrl !== profileUrl) {
         promiseArray.push(queueNetworkRequestMemoized("url", normalizeProfileURL(translatedUrl)));
     }
-    const data = await Promise.all(promiseArray);
-    const artistUrls = [].concat([], ...data);
+    const artistUrls = (await Promise.all(promiseArray)).flat();
     const artists = artistUrls.map((artistUrl) => artistUrl.artist);
 
     if (artists.length === 0) {

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -758,14 +758,6 @@ async function translateArtistByURL (element, profileUrl, options) {
         return;
     }
 
-    // New fix of #18 v2
-    // Dabooru does unwanted reverse search
-    // which returns trashy results
-    // and there are exaclty 10 artists
-    if (artists.length === 10) {
-        debuglog(`The results for "${profileUrl}" were rejected, rule "${options.ruleName}"`);
-        return;
-    }
     artists.forEach((artist) => addDanbooruArtist($(element), artist, options));
 }
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -165,10 +165,6 @@ const POST_FIELDS = [
     "tag_string",
 ].join(",");
 const POST_COUNT_FIELDS = "post_count";
-const TAG_FIELDS = "name,category";
-const WIKI_FIELDS = "title,category_name,other_names";
-const ARTIST_FIELDS = "id,name,is_banned,other_names,urls";
-const TAG_ALIASES_FIELDS = "antecedent_name,consequent_name";
 
 // Settings for artist tooltips.
 const ARTIST_QTIP_SETTINGS = {
@@ -328,90 +324,81 @@ const CACHE_PARAM = (CACHE_LIFETIME ? { expires_in: CACHE_LIFETIME } : {});
 // Setting this to the maximum since batches could return more than the amount being queried
 const LIMIT_PARAM = { limit: 1000 };
 
-function WikiParams (otherNamesList) {
-    return {
-        search: {
-            other_names_include_any_lower_array: otherNamesList,
-            is_deleted: false,
-        },
-        only: WIKI_FIELDS,
-    };
-}
-
-function ArtistParams (nameList) {
-    return {
-        search: {
-            name_lower_comma: nameList.join(","),
-            is_active: true,
-        },
-        only: ARTIST_FIELDS,
-    };
-}
-
-function TagParams (nameList) {
-    return {
-        search: {
-            name_lower_comma: nameList.join(","),
-        },
-        only: TAG_FIELDS,
-    };
-}
-
-function AliasParams (nameList) {
-    return {
-        search: {
-            antecedent_name_lower_comma: nameList.join(","),
-        },
-        only: TAG_ALIASES_FIELDS,
-    };
-}
-
-function UrlParams (urlList) {
-    return {
-        search: {
-            normalized_url_lower_array: urlList,
-        },
-        // The only parameter does not work with artist urls... yet
-    };
-}
-
-function UrlFilter (artistUrls) {
-    return artistUrls.filter((artistUrl) => artistUrl.artist.is_active);
-}
 
 const QUEUED_NETWORK_REQUESTS = [];
 
 const NETWORK_REQUEST_DICT = {
     wiki: {
         url: "/wiki_pages",
-        params: WikiParams,
         data_key: "other_names",
         data_type: "array",
+        fields: "title,category_name,other_names",
+        params (otherNamesList) {
+            return {
+                search: {
+                    other_names_include_any_lower_array: otherNamesList,
+                    is_deleted: false,
+                },
+                only: this.fields,
+            };
+        },
     },
     artist: {
         url: "/artists",
-        params: ArtistParams,
         data_key: "name",
         data_type: "string",
+        fields: "id,name,is_banned,other_names,urls",
+        params (nameList) {
+            return {
+                search: {
+                    name_lower_comma: nameList.join(","),
+                    is_active: true,
+                },
+                only: this.fields,
+            };
+        },
     },
     tag: {
         url: "/tags",
-        params: TagParams,
         data_key: "name",
         data_type: "string",
+        fields: "name,category",
+        params (nameList) {
+            return {
+                search: {
+                    name_lower_comma: nameList.join(","),
+                },
+                only: this.fields,
+            };
+        },
     },
     alias: {
         url: "/tag_aliases",
-        params: AliasParams,
         data_key: "antecedent_name",
         data_type: "string",
+        fields: "antecedent_name,consequent_name",
+        params (nameList) {
+            return {
+                search: {
+                    antecedent_name_lower_comma: nameList.join(","),
+                },
+                only: this.fields,
+            };
+        },
     },
     url: {
         url: "/artist_urls",
-        params: UrlParams,
-        filter: UrlFilter,
         data_key: "normalized_url",
         data_type: "string",
+        params (urlList) {
+            return {
+                search: {
+                    normalized_url_lower_array: urlList,
+                },
+                // The only parameter does not work with artist urls... yet
+            };
+        },
+        filter: (artistUrls) => artistUrls.filter((artistUrl) => artistUrl.artist.is_active),
     },
 };
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -448,6 +448,15 @@ const safeMatchMemoized = _.memoize(safeMatch, memoizeKey);
 const TRANSLATE_PROFILE_URL = [{
     regex: /https?:\/\/www\.pixiv\.net(?:\/en)?\/users\/(\d+)/,
     replace: "https://www.pixiv.net/member.php?id=%REPLACE%",
+}, {
+    regex: /https?:\/\/www\.deviantart\.com\/([\w-]+)/,
+    replace: "https://%REPLACE%.deviantart.com",
+}, {
+    regex: /https?:\/\/www\.artstation\.com\/([\w-]+)/,
+    replace: "https://%REPLACE%.artstation.com",
+}, {
+    regex: /https?:\/\/([\w-]+)\.artstation\.com/,
+    replace: "https://www.artstation.com/%REPLACE%",
 }];
 
 function translateProfileURL (profileUrl) {

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -415,6 +415,12 @@ const NETWORK_REQUEST_DICT = {
     },
 };
 
+function debuglog (...args) {
+    if (DEBUG) {
+        console.log(...args);
+    }
+}
+
 function memoizeKey (...args) {
     const paramHash = Object.assign(...args.map((param, i) => ({ [i]: param })));
     return $.param(paramHash);
@@ -711,9 +717,7 @@ async function translateTag (target, tagName, options) {
     }
 
     if (tags.length === 0) {
-        if (DEBUG) {
-            console.log(`No translation for "${normalizedTag}", rule "${options.ruleName}"`);
-        }
+        debuglog(`No translation for "${normalizedTag}", rule "${options.ruleName}"`);
         return;
     }
 
@@ -761,9 +765,7 @@ async function translateArtistByURL (element, profileUrl, options) {
     const artists = artistUrls.map((artistUrl) => artistUrl.artist);
 
     if (artists.length === 0) {
-        if (DEBUG) {
-            console.log(`No artist at "${profileUrl}", rule "${options.ruleName}"`);
-        }
+        debuglog(`No artist at "${profileUrl}", rule "${options.ruleName}"`);
         return;
     }
 
@@ -772,9 +774,7 @@ async function translateArtistByURL (element, profileUrl, options) {
     // which returns trashy results
     // and there are exaclty 10 artists
     if (artists.length === 10) {
-        if (DEBUG) {
-            console.log(`The results for "${profileUrl}" were rejected, rule "${options.ruleName}"`);
-        }
+        debuglog(`The results for "${profileUrl}" were rejected, rule "${options.ruleName}"`);
         return;
     }
     artists.forEach((artist) => addDanbooruArtist($(element), artist, options));
@@ -786,9 +786,7 @@ async function translateArtistByName (element, artistName, options) {
     const artists = await queueNetworkRequestMemoized("artist", artistName.replace(/ /g, "_"));
 
     if (artists.length === 0) {
-        if (DEBUG) {
-            console.log(`No artist "${artistName}", rule "${options.ruleName}"`);
-        }
+        debuglog(`No artist "${artistName}", rule "${options.ruleName}"`);
         return;
     }
 

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -416,7 +416,8 @@ const NETWORK_REQUEST_DICT = {
 };
 
 function memoizeKey (...args) {
-    return JSON.stringify(args);
+    const paramHash = Object.assign(...args.map((param, i) => ({ [i]: param })));
+    return $.param(paramHash);
 }
 
 // Tag function for template literals to remove newlines and leading spaces
@@ -2472,10 +2473,6 @@ function initialize () {
     GM_addStyle(PROGRAM_CSS);
     GM_addStyle(GM_getResourceText("jquery_qtip_css"));
     GM_registerMenuCommand("Settings", showSettings, "S");
-    // So that JSON stringify can be used to generate memoize keys
-    /* eslint-disable no-extend-native */
-    RegExp.prototype.toJSON = RegExp.prototype.toString;
-    /* eslint-enable no-extend-native */
 
     switch (window.location.host) {
         case "www.pixiv.net":


### PR DESCRIPTION
This uses the recent methods of performing batch queries supplied by https://github.com/danbooru/danbooru/pull/4268 and https://github.com/danbooru/danbooru/pull/4273.

Batching has several advantages over querying individually, as it is less resource intensive on both the client and the server, plus there is no need for rate limiting since it is already limited to at most 5 requests per half-second. One disadvantage is that it cannot take as much advantage of caching as the individual queries can. In this case though, I believe the advantages very much outweighs the disadvantages.

Session storage could be used to temporarily store results for a limited time period, although that would need to be a separate PR. I've got experience doing this with my own scripts, so if that is something that is desired then I can whip up something.

Finally, I left all of the old network code in for now, but after a transitory period the rate limiting portion could be removed as the only thing using those now are the network requests for the qTips.

Besides the network batches, I also changed the key generation so that the comment and linter disable don't have to be used, and changed the debug logging so that IF blocks don't have to be used in so many places.