### PR TITLE
Fix artist network queries

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -368,12 +368,13 @@ const NETWORK_REQUEST_DICT = {
         url: "/artist_urls",
         data_key: "normalized_url",
         data_type: "string",
+        fields: "normalized_url,artist[id,name,other_names,is_active,urls[normalized_url,is_active]]",
         params (urlList) {
             return {
                 search: {
                     normalized_url_lower_array: urlList,
                 },
-                // The only parameter does not work with artist urls... yet
+                only: this.fields,
             };
         },
         filter: (artistUrls) => artistUrls.filter((artistUrl) => artistUrl.artist.is_active),


### PR DESCRIPTION
- Caused by the removal of the artist and artist URLs by default
-- danbooru/danbooru@8649ff6
- Make use of the now available nested only parameter to add in necessary includes
-- danbooru/danbooru@63b3503

The nested only parameter can also be used to combine the tag alias and queries into one, but I wanted to get this fix out quick, and that combining will require more testing.