### PR TITLE
Fix sound

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Translate Pixiv Tags
 // @author       evazion, 7nik, BrokenEagle
-// @version      20230706134746
+// @version      20230717025146
 // @description  Translates tags on Pixiv, Nijie, NicoSeiga, Tinami, and BCY to Danbooru tags.
 // @homepageURL  https://github.com/evazion/translate-pixiv-tags
 // @supportURL   https://github.com/evazion/translate-pixiv-tags/issues

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1763,7 +1763,7 @@ const ARTIST_TOOLTIP_CSS = `
         z-index: 1;
     }
 
-    article.post-preview[data-has-sound=true]::before {
+    article.post-preview[data-tags~=sound]::before {
         content: "♪";
         position: absolute;
         width: 20px;
@@ -2064,7 +2064,6 @@ function buildPostPreview (post) {
 
     const dataAttributes = `
       data-id="${post.id}"
-      data-has-sound="${Boolean(post.tag_string.match(/(video_with_sound|flash_with_sound)/))}"
       data-tags="${_.escape(post.tag_string)}"
     `;
 


### PR DESCRIPTION
Both `video_with_sound` and `flash_with_sound` were aliased to `sound` a bit over two years ago: https://danbooru.donmai.us/forum_topics/18818. How no one noticed this over that period?