### PR TITLE
Artist tooltip post preview improvements

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1677,7 +1677,7 @@ const ARTIST_TOOLTIP_CSS = `
         margin: 0 2px 10px 0;
     }
 
-    article.post-preview a {
+    article.post-preview a.post-link {
         margin: auto;
         border: 2px solid transparent;
         display: inline-block;
@@ -2123,7 +2123,7 @@ function buildPostPreview (post) {
                  itemtype="http://schema.org/ImageObject"
                  class="${previewClass}"
                  ${dataAttributes} >
-            <a href="${BOORU}/posts/${post.id}" target="_blank">
+            <a class="post-link" href="${BOORU}/posts/${post.id}" target="_blank">
                 ${animationIcon}
                 <img width="${previewWidth}"
                      height="${previewHeight}"

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1758,6 +1758,7 @@ const ARTIST_TOOLTIP_CSS = `
         background-color: rgba(0,0,0,0.7);
         line-height: 1;
         padding: 2px;
+        z-index: 1;
     }
     article.post-preview .post-animation-icon * {
         height: 1em;

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Translate Pixiv Tags
 // @author       evazion, 7nik, BrokenEagle
-// @version      20230717025146
+// @version      20230730145846
 // @description  Translates tags on Pixiv, Nijie, NicoSeiga, Tinami, and BCY to Danbooru tags.
 // @homepageURL  https://github.com/evazion/translate-pixiv-tags
 // @supportURL   https://github.com/evazion/translate-pixiv-tags/issues

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -666,7 +666,7 @@ const NETWORK_REQUEST_DICT = {
     // This can only be used as a single use and not as part a group
     post: {
         url: "/posts",
-        data_key: "tag_string",
+        data_key: "tag_string_artist",
         data_type: "string_list",
         fields: [
             "created_at",
@@ -679,7 +679,11 @@ const NETWORK_REQUEST_DICT = {
             "media_asset[id,file_ext,file_size,image_width,image_height,duration,variants]",
             "rating",
             "source",
-            "tag_string",
+            "tag_string_general",
+            "tag_string_character",
+            "tag_string_copyright",
+            "tag_string_artist",
+            "tag_string_meta",
         ].join(","),
         params (tagList) {
             return {
@@ -2041,6 +2045,21 @@ function formatBytes (bytes) {
     return `${parseFloat((bytes / (1024 ** i)).toFixed(2))} ${sizes[i]}`;
 }
 
+function formatTagString (post) {
+    return _([
+        post.tag_string_artist,
+        post.tag_string_copyright,
+        post.tag_string_character,
+        post.tag_string_meta,
+        post.tag_string_general,
+    ])
+        .chain()
+        .compact()
+        .join("\n")
+        .escape()
+        .value();
+}
+
 function buildPostPreview (post) {
     const RATINGS = {
         g: 0,
@@ -2061,7 +2080,7 @@ function buildPostPreview (post) {
 
     const dataAttributes = `
       data-id="${post.id}"
-      data-tags="${_.escape(post.tag_string)}"
+      data-tags="${formatTagString(post)}"
     `;
 
     let previewFileUrl, previewWidth, previewHeight;
@@ -2087,7 +2106,7 @@ function buildPostPreview (post) {
         ? `${formatBytes(post.media_asset.file_size)} .${post.media_asset.file_ext}, <a href="${BOORU}/media_assets/${post.media_asset.id}">${post.media_asset.image_width}x${post.media_asset.image_height}</a>`
         : "";
 
-    const soundIcon = post.tag_string.match(/\bsound\b/)
+    const soundIcon = post.tag_string_meta.match(/\bsound\b/)
         ? GM_getResourceText("sound_icon")
         : "";
     const animationIcon = post.media_asset.duration
@@ -2109,7 +2128,7 @@ function buildPostPreview (post) {
                 <img width="${previewWidth}"
                      height="${previewHeight}"
                      src="${previewFileUrl}"
-                     title="${_.escape(post.tag_string)}"
+                     title="${formatTagString(post)}"
                      part="post-preview rating-${post.rating}">
             </a>
             <p>${imgSize}</p>

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -676,7 +676,7 @@ const NETWORK_REQUEST_DICT = {
             "is_pending",
             "is_deleted",
             "parent_id",
-            "media_asset[file_ext,file_size,image_width,image_height,duration,variants]",
+            "media_asset[id,file_ext,file_size,image_width,image_height,duration,variants]",
             "rating",
             "source",
             "tag_string",
@@ -1826,6 +1826,10 @@ const ARTIST_TOOLTIP_CSS = `
         letter-spacing: -0.1px;
     }
 
+    article.post-preview p a {
+        display: inline;
+    }
+
     article.post-preview.blur-post img {
         filter: blur(10px);
     }
@@ -2077,10 +2081,10 @@ function buildPostPreview (post) {
     }
 
     const domain = post.source.match(/^https?:\/\//)
-        ? getSiteDisplayDomain(post.source)
-        : "NON-WEB";
+        ? `<a href="${post.source}">${getSiteDisplayDomain(post.source)}</a>`
+        : `<span title="${post.source}">NON-WEB</span>`;
     const imgSize = [post.media_asset.file_size, post.media_asset.image_width, post.media_asset.image_height].every(_.isFinite)
-        ? `${formatBytes(post.media_asset.file_size)} (${post.media_asset.image_width}x${post.media_asset.image_height})`
+        ? `${formatBytes(post.media_asset.file_size)} .${post.media_asset.file_ext}, <a href="${BOORU}/media_assets/${post.media_asset.id}">${post.media_asset.image_width}x${post.media_asset.image_height}</a>`
         : "";
 
     const soundIcon = post.tag_string.match(/\bsound\b/)

--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -2100,8 +2100,8 @@ function buildPostPreview (post) {
     }
 
     const domain = post.source.match(/^https?:\/\//)
-        ? `<a href="${post.source}">${getSiteDisplayDomain(post.source)}</a>`
-        : `<span title="${post.source}">NON-WEB</span>`;
+        ? `<a href="${_.escape(post.source)}">${getSiteDisplayDomain(post.source)}</a>`
+        : `<span title="${_.escape(post.source)}">NON-WEB</span>`;
     const imgSize = [post.media_asset.file_size, post.media_asset.image_width, post.media_asset.image_height].every(_.isFinite)
         ? `${formatBytes(post.media_asset.file_size)} .${post.media_asset.file_ext}, <a href="${BOORU}/media_assets/${post.media_asset.id}">${post.media_asset.image_width}x${post.media_asset.image_height}</a>`
         : "";


### PR DESCRIPTION
Few additions I personally need/use:
1. Show duration and sound icon for animated posts, the same way danbooru itself currently does;
2. Fix thumbnails for .swf;
3. Show file format along currently shown file size and dimensions;
4. Add links to the original source page and post media asset page;
5. Group tags by category, the same way they are initially grouped in tag string field on post edit form on danbooru.