### PR TITLE
Do not escape asterisks for wiki page search

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Translate Pixiv Tags
 // @author       evazion, 7nik, BrokenEagle, hdk5
-// @version      20231108095921
+// @version      20231119194412
 // @description  Translates tags on Pixiv, Nijie, NicoSeiga, Tinami, and BCY to Danbooru tags.
 // @homepageURL  https://github.com/evazion/translate-pixiv-tags
 // @supportURL   https://github.com/evazion/translate-pixiv-tags/issues
@@ -1305,7 +1305,6 @@ async function translateTag (target, tagName, options) {
         .normalize("NFKC")
         .replace(/^#/, "")
         .trim()
-        .replace(/[*]/g, "\\*") // Escape * (wildcard)
         .replace(/\s/g, "_"); // Wiki other names cannot contain spaces
 
     /* Don't search for empty tags. */


### PR DESCRIPTION
e.g. [千恋*万花](https://www.pixiv.net/tags/千恋*万花/artworks)

`*` escape was introduced in https://github.com/evazion/translate-pixiv-tags/commit/122697ff384e732f4e589710c0b9a1bdde77ee8c, when the search was made using `other_names_match` param
After https://github.com/evazion/translate-pixiv-tags/commit/6fff4556d7cceeb881b55b40f632b04822593db6, the search is performed with `other_names_include_any_lower_array`, which doesn't treat `*` as wildcard and takes it as is - see https://github.com/danbooru/danbooru/blob/91178f37990dbac65766c905d8717d93ea1df731/app/models/wiki_page.rb#L49