### PR TITLE
Specify referrerpolicy for thumbnail img element

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -2603,6 +2603,7 @@ function buildPostPreview (post) {
                      height="${preview.height}"
                      src="${preview.url}"
                      title="${formatTagString(post)}"
+                     referrerpolicy="origin"
                      part="post-preview rating-${post.rating}">
             </a>
             <p>${formatImageInfo(post)}</p>


### PR DESCRIPTION
Apparently, danbooru's cdn is not happy anymore with cross-origin requests without the referer header.
This breaks post thumbnails on artist tooltips on at least pawoo, baraag, and maybe some other sites too.