### PR TITLE
baraag: fix hashtag bar appearance

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -4118,6 +4118,7 @@ function initializeMastodon () {
         predicate: ".hashtag-bar a[href^='/tags/']",
         ruleName: "tags bar",
         asyncMode: true,
+        tagPosition: TAG_POSITIONS.beforeend,
     });
 }
 


### PR DESCRIPTION
Small visual fix.
pawoo runs much older Mastodon version and displays hashtags only inside the post, and therefore is unaffected

from:
![a](https://github.com/user-attachments/assets/ac400038-ef75-4fe3-8d05-6218c2d5a949)
to:
![a](https://github.com/user-attachments/assets/8c070d1f-a6cb-4334-a5bc-a6c5f8701a40)

