### PR TITLE
fix(artist): add filtering logic to prioritize artists with active URLs

### DIFF
--- a/translate-pixiv-tags.user.js
+++ b/translate-pixiv-tags.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         Translate Pixiv Tags
 // @author       evazion, 7nik, BrokenEagle, hdk5
-// @version      20250611075610
+// @version      20250621184700
 // @description  Translates tags on Pixiv, Nijie, NicoSeiga, Tinami, and BCY to Danbooru tags.
 // @homepageURL  https://github.com/evazion/translate-pixiv-tags
 // @supportURL   https://github.com/evazion/translate-pixiv-tags/issues
@@ -2544,7 +2544,18 @@ async function translateArtistByURL (element, profileUrl, options) {
         return;
     }
 
-    for (const artist of artists) addDanbooruArtist($(element), artist, options);
+    let filteredArtists = artists;
+    if (artists.length > 1) {
+        filteredArtists = artists.filter(artist => {
+            return artist.urls.some(urlObj => urlObj.is_active);
+        });
+        
+        if (filteredArtists.length === 0) {
+            filteredArtists = artists;
+        }
+    }
+
+    for (const artist of filteredArtists) addDanbooruArtist($(element), artist, options);
 }
 
 /**


### PR DESCRIPTION
Resolves the confusing display issue when multiple artists share the same Twitter handle.

The new filtering logic prioritizes artists with active URLs, ensuring only the most relevant artist record is shown to users.

![Snipaste_2025-06-22_02-05-22](https://github.com/user-attachments/assets/f55ef856-2621-4920-ab44-34e8412e9185)